### PR TITLE
Fixed issue with connection to legacy DB.

### DIFF
--- a/src/lib/legacydb.js
+++ b/src/lib/legacydb.js
@@ -14,7 +14,7 @@ set_connection()
 
     // If we already have the connection, exit.
     if (database_connection != null)
-        return;
+        return database_connection;
 
     // Otherwise, create the connection.
     database_connection = mysql.createConnection({


### PR DESCRIPTION
Initial connection works.
Problem occurs when attempting connection when already established.
set_connection() returned an empty object instead of the non-null db connection.